### PR TITLE
Update desktop_oauth2.dart

### DIFF
--- a/lib/src/desktop_oauth2.dart
+++ b/lib/src/desktop_oauth2.dart
@@ -58,6 +58,7 @@ class DesktopOAuth2 {
   Future<Map<String, dynamic>?> _fetchAccessToken(DesktopAuthorizationCodeFlow desktopAuthCodeFlow, String code, {String? codeVerifier}) async {
     Map<String, String> tokenReqPayload = {
       'client_id': desktopAuthCodeFlow.clientId,
+      'client_secret': desktopAuthCodeFlow.clientSecret!,
       'redirect_uri': desktopAuthCodeFlow.redirectUri,
       'grant_type': 'authorization_code',
       'code': code
@@ -87,7 +88,6 @@ class DesktopOAuth2 {
 
       return _login(desktopAuthCodeFlow, authUrl, codeVerifier: pkcePair.codeVerifier);
     } else {
-      params.write("&client_secret=${desktopAuthCodeFlow.clientSecret}");
       final Uri authUrl = Uri.parse('${desktopAuthCodeFlow.authorizationUrl}?${params.toString()}');
 
       return _login(desktopAuthCodeFlow, authUrl);


### PR DESCRIPTION
Fix Issue #2 

When user forces pkce=false, _fetchAccessToken will pass clientSecret in tokenReqPayload, which avoids failure. I found that leaving pkce=true is also successful when passing clientSecret through.