### PR TITLE
Fix Issue #2

### DIFF
--- a/lib/src/desktop_oauth2.dart
+++ b/lib/src/desktop_oauth2.dart
@@ -62,7 +62,7 @@ class DesktopOAuth2 {
       'grant_type': 'authorization_code',
       'code': code
     };
-    if (desktopAuthCodeFlow.pkce = false) {
+    if (desktopAuthCodeFlow.pkce == false) {
       final clientSecret = <String, String>{
         'client_secret': desktopAuthCodeFlow.clientSecret!
       };

--- a/lib/src/desktop_oauth2.dart
+++ b/lib/src/desktop_oauth2.dart
@@ -58,6 +58,7 @@ class DesktopOAuth2 {
   Future<Map<String, dynamic>?> _fetchAccessToken(DesktopAuthorizationCodeFlow desktopAuthCodeFlow, String code, {String? codeVerifier}) async {
     Map<String, String> tokenReqPayload = {
       'client_id': desktopAuthCodeFlow.clientId,
+      'client_secret': desktopAuthCodeFlow.clientSecret!,
       'redirect_uri': desktopAuthCodeFlow.redirectUri,
       'grant_type': 'authorization_code',
       'code': code
@@ -87,7 +88,6 @@ class DesktopOAuth2 {
 
       return _login(desktopAuthCodeFlow, authUrl, codeVerifier: pkcePair.codeVerifier);
     } else {
-      params.write("&client_secret=${desktopAuthCodeFlow.clientSecret}");
       final Uri authUrl = Uri.parse('${desktopAuthCodeFlow.authorizationUrl}?${params.toString()}');
 
       return _login(desktopAuthCodeFlow, authUrl);

--- a/lib/src/desktop_oauth2.dart
+++ b/lib/src/desktop_oauth2.dart
@@ -58,12 +58,16 @@ class DesktopOAuth2 {
   Future<Map<String, dynamic>?> _fetchAccessToken(DesktopAuthorizationCodeFlow desktopAuthCodeFlow, String code, {String? codeVerifier}) async {
     Map<String, String> tokenReqPayload = {
       'client_id': desktopAuthCodeFlow.clientId,
-      'client_secret': desktopAuthCodeFlow.clientSecret!,
       'redirect_uri': desktopAuthCodeFlow.redirectUri,
       'grant_type': 'authorization_code',
       'code': code
     };
-
+    if (desktopAuthCodeFlow.pkce = false) {
+      final clientSecret = <String, String>{
+        'client_secret': desktopAuthCodeFlow.clientSecret!
+      };
+      tokenReqPayload.addEntries(clientSecret.entries);
+    }
     if (codeVerifier != null) tokenReqPayload.putIfAbsent("code_verifier", () => codeVerifier);
 
     final response = await http.post(Uri.parse(desktopAuthCodeFlow.tokenUrl), body: tokenReqPayload);


### PR DESCRIPTION
Fix Issue #2 

When user forces pkce=false, _fetchAccessToken will pass clientSecret in tokenReqPayload, which avoids failure. I found that leaving pkce=true/not declaring pkce is also successful when passing clientSecret through.